### PR TITLE
Centralize dayjs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,24 +1,10 @@
 import "@/app/globals.css";
 import { Toaster } from "@/components/ui/sonner";
-import dayjs from "dayjs";
-import "dayjs/plugin/duration";
-import "dayjs/plugin/relativeTime";
-import "dayjs/plugin/utc";
+import dayjs from "@/lib/dayjs";
 import type { Metadata } from "next";
 
 import QueryClientProviderWrapper from "@/components/atoms/QueryClientProvider";
-import duration from "dayjs/plugin/duration";
-import relativeTime from "dayjs/plugin/relativeTime";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-import weekOfYear from "dayjs/plugin/weekOfYear";
 import { SessionProvider } from "next-auth/react";
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.extend(duration);
-dayjs.extend(relativeTime);
-dayjs.extend(weekOfYear);
 
 export const metadata: Metadata = {
   title: `${dayjs().format("MMMM, YYYY")} · Koano`,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ import {
   getDayObjectFromId,
   getDayObjectWithDate,
 } from "@/lib/utils";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { useSession } from "next-auth/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 

--- a/src/components/atoms/Event.tsx
+++ b/src/components/atoms/Event.tsx
@@ -6,7 +6,7 @@ import { useSettingStore } from "@/lib/stores/settings";
 import { Clock, Event as EventType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useDraggable } from "@dnd-kit/core";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { CSSProperties, useEffect, useMemo, useState } from "react";
 
 interface Props {

--- a/src/components/atoms/TimeBlock.tsx
+++ b/src/components/atoms/TimeBlock.tsx
@@ -5,7 +5,7 @@ import { useDataStore } from "@/lib/stores/data";
 import { useSettingStore } from "@/lib/stores/settings";
 import { Clock } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { memo, useEffect, useState } from "react";
 
 interface Props {

--- a/src/components/molecules/Day.tsx
+++ b/src/components/molecules/Day.tsx
@@ -21,7 +21,7 @@ import {
   getTimeFromPixelOffset,
 } from "@/lib/utils";
 import { useDroppable } from "@dnd-kit/core";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface Props {

--- a/src/components/molecules/Sidebar.tsx
+++ b/src/components/molecules/Sidebar.tsx
@@ -4,7 +4,7 @@ import { useEventStore } from "@/lib/stores/event";
 import { useSettingStore } from "@/lib/stores/settings";
 import { EventSchema } from "@/lib/validators";
 import { zodResolver } from "@hookform/resolvers/zod";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { ArrowRight, Clock9, TrashIcon } from "lucide-react";
 
 import { Calendar } from "@/components/ui/calendar";

--- a/src/components/templates/Grid.tsx
+++ b/src/components/templates/Grid.tsx
@@ -2,7 +2,7 @@ import Event from "@/components/atoms/Event";
 import Logo from "@/components/atoms/Logo";
 import Day from "@/components/molecules/Day";
 import { DndContext, DragEndEvent, closestCenter } from "@dnd-kit/core";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useDebounceCallback, useWindowSize } from "usehooks-ts";
 

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,16 @@
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import weekOfYear from "dayjs/plugin/weekOfYear";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
+dayjs.extend(weekOfYear);
+dayjs.extend(customParseFormat);
+
+export default dayjs;

--- a/src/lib/stores/data.ts
+++ b/src/lib/stores/data.ts
@@ -1,6 +1,6 @@
 import { repeatValues } from "@/lib/consts";
 import { Clock, TimeObject } from "@/lib/types";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 

--- a/src/lib/stores/event.ts
+++ b/src/lib/stores/event.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/api/event";
 import { ErrorResponse, Status } from "@/lib/api/types";
 import { useContextStore } from "@/lib/stores/context";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { create } from "zustand";
 
 type EventStore = {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,6 +1,6 @@
 import { useDataStore } from "@/lib/stores/data";
 import { Settings } from "@/lib/types";
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+import dayjs from "@/lib/dayjs";
 
 export type User = {
   id: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,18 +1,8 @@
 import { PIXEL_PER_HOUR, PIXEL_PER_QUARTER } from "@/lib/consts";
 import { Picker } from "@/lib/types";
 import { clsx, type ClassValue } from "clsx";
-import dayjs from "dayjs";
-import "dayjs/plugin/duration";
-import "dayjs/plugin/relativeTime";
-import "dayjs/plugin/utc";
+import dayjs from "@/lib/dayjs";
 import { twMerge } from "tailwind-merge";
-
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/timezone"));
-dayjs.extend(require("dayjs/plugin/duration"));
-dayjs.extend(require("dayjs/plugin/relativeTime"));
-dayjs.extend(require("dayjs/plugin/weekOfYear"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
## Summary
- add a central `dayjs` setup
- use shared instance across the app

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe56e5488332926649e8948c49aa