### PR TITLE
Implement multi-day event segments

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,7 +9,7 @@ This is a list of features that I would like to implement in to the complete pro
 - [x] Drag and drop events to move them to another day.
 - [x] Real-time previews while creating, editing, or moving events.
 - [x] Timezone support across views and events.
-- [ ] Multi-day spanning events.
+- [x] Multi-day spanning events.
 - [ ] Recurring events (daily/weekly/monthly/custom)
 - [ ] Monthly and yearly calendar views.
 - [ ] Context menu for quick actions (e.g., save/discard)

--- a/src/components/atoms/Event.tsx
+++ b/src/components/atoms/Event.tsx
@@ -12,9 +12,11 @@ import { CSSProperties, useEffect, useMemo, useState } from "react";
 interface Props {
   event: EventType;
   active: boolean;
+  displayStart: Date;
+  displayEnd: Date;
 }
 
-export default function Event({ event, active }: Props) {
+export default function Event({ event, active, displayStart, displayEnd }: Props) {
   const [y, setY] = useState(0);
   const [label, setLabel] = useState("");
   const [height, setHeight] = useState(0);
@@ -50,19 +52,19 @@ export default function Event({ event, active }: Props) {
 
   useEffect(() => {
     setY(
-      dayjs(event.start_time).diff(dayjs(event.start_time).startOf("d"), "m") *
+      dayjs(displayStart).diff(dayjs(displayStart).startOf("d"), "m") *
         PIXEL_PER_MINUTE,
     );
     setHeight(
-      dayjs(event.end_time).diff(event.start_time, "minute") * PIXEL_PER_MINUTE,
+      dayjs(displayEnd).diff(displayStart, "minute") * PIXEL_PER_MINUTE,
     );
-  }, [event]);
+  }, [displayStart, displayEnd]);
 
   useEffect(() => {
     setLabel(
-      generateEventTime(event.start_time, event.end_time, settings.clock),
+      generateEventTime(displayStart, displayEnd, settings.clock),
     );
-  }, [settings, event]);
+  }, [settings, displayStart, displayEnd]);
 
   useEffect(() => {
     if (transform) {
@@ -79,7 +81,11 @@ export default function Event({ event, active }: Props) {
         active ? "bg-orange-300" : "bg-orange-500",
       )}
       style={style}>
-      <Dragger className="top-0" compact={height <= 30 * PIXEL_PER_MINUTE} />
+      <Dragger
+        className="top-0"
+        type="start"
+        compact={height <= 30 * PIXEL_PER_MINUTE}
+      />
       <span
         className={cn(
           "flex h-full font-medium text-foreground",
@@ -101,7 +107,11 @@ export default function Event({ event, active }: Props) {
         <p className="truncate text-sm">{event.title}</p>
         <p className="text-xs opacity-75">{label}</p>
       </span>
-      <Dragger className="bottom-0" compact={height <= 30 * PIXEL_PER_MINUTE} />
+      <Dragger
+        className="bottom-0"
+        type="end"
+        compact={height <= 30 * PIXEL_PER_MINUTE}
+      />
     </div>
   );
 }
@@ -109,13 +119,16 @@ export default function Event({ event, active }: Props) {
 function Dragger({
   className,
   compact,
+  type,
 }: {
   className?: string;
   compact: boolean;
+  type: "start" | "end";
 }) {
   return (
     <span
       id={DRAGGER_ID}
+      data-dragger={type}
       style={{
         height: compact ? PIXEL_PER_MINUTE * 2.5 : PIXEL_PER_QUARTER,
       }}

--- a/src/components/templates/Grid.tsx
+++ b/src/components/templates/Grid.tsx
@@ -215,14 +215,7 @@ export default function Grid({
           return;
         }
 
-        if (
-          dayjs(start_time).format("MM/DD/YYYY") !==
-            dayjs(end_time).format("MM/DD/YYYY") &&
-          dayjs(end_time).format("h:mm A") !== "12:00 AM"
-        ) {
-          setDragging(false);
-          return;
-        }
+
 
         editEvent({ ...event, start_time, end_time });
       }
@@ -297,18 +290,34 @@ export default function Grid({
               day={dayjs(date).startOf("day").toDate()}>
               {events.length > 0 &&
                 events
-                  .filter(
-                    (event) =>
-                      dayjs(event.start_time).format("DD/MM/YYYY") ===
-                      dayjs(date).format("DD/MM/YYYY"),
-                  )
-                  .map((event) => (
-                    <Event
-                      key={event.id}
-                      event={event}
-                      active={event.id === activeEvent?.id}
-                    />
-                  ))}
+                  .filter((event) => {
+                    const start = dayjs(event.start_time);
+                    const end = dayjs(event.end_time);
+                    const dayStart = dayjs(date).startOf("day");
+                    const dayEnd = dayjs(date).endOf("day");
+                    return start.isBefore(dayEnd) && end.isAfter(dayStart);
+                  })
+                  .map((event) => {
+                    const dayStart = dayjs(date).startOf("day");
+                    const dayEnd = dayjs(date).endOf("day");
+                    const displayStart =
+                      dayjs(event.start_time).isAfter(dayStart)
+                        ? event.start_time
+                        : dayStart.toDate();
+                    const displayEnd =
+                      dayjs(event.end_time).isBefore(dayEnd)
+                        ? event.end_time
+                        : dayEnd.toDate();
+                    return (
+                      <Event
+                        key={`${event.id}-${dayStart.format("YYYY-MM-DD")}`}
+                        event={event}
+                        displayStart={displayStart}
+                        displayEnd={displayEnd}
+                        active={event.id === activeEvent?.id}
+                      />
+                    );
+                  })}
             </Day>
           ))
         )}


### PR DESCRIPTION
## Summary
- support events that span multiple days by slicing events per day in Grid view
- mark multi-day events as completed in feature roadmap
- allow dragging and resizing multi-day events across days

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683fff9cc890833297b5ecfff7ac8cf3